### PR TITLE
Fix handling of slash-escaped characters in the page title

### DIFF
--- a/build_link_map.py
+++ b/build_link_map.py
@@ -48,11 +48,12 @@ def build_link_map(directory):
             continue
         text = m.group(1)
         text = re.sub(r'\s*', '', text)
-        m = re.search('"wgPageName":"([^"]*)"', text)
+        m = re.search(r'"wgPageName":"((\\.|[^"\\])*)"', text) # also match escaped quotes \"
         if not m:
             continue
 
         title = m.group(1)
+        title = title.replace(r'\"', r'"') # replace escaped quotes with plain quotes
 
         target = os.path.relpath(os.path.abspath(fn),
                                  os.path.abspath(directory))


### PR DESCRIPTION
Implements the fix described in #31.

Issue: `operator""sv` (and many others) contain quote characters which appear as `operator\"\"sv` in HTML, but the regex in `build_link_map.py` stops at the first (escaped) quote which results in broken links in `output/link-map.xml`. Instead, the regex is adjusted to eat all slash-escaped characters until the real quote. Then the escaped quotes are converted to plain quotes and correctly appear as `operator&quot;&quot;sv` in the final `output/link-map.xml` (which eventually works in `devhelp`).

Playground for regex: https://regex101.com/r/qCPJhi/1