### PR TITLE
ci(Makefile): Use system-agnostic path for bash.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see http://www.gnu.org/licenses/.
 
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 #Common prefixes
 


### PR DESCRIPTION
Currently the `SHELL` variable in the Makefile uses `/bin/bash` as a shell. This would normally work except for the users that have the `bash` executable installed somewhere else on their system. (Example: NixOS users, like me) Using `/usr/bin/env bash` will ensure that the `bash` executable is found on any system.

Simply changing this line solved this issue for me.